### PR TITLE
Sequential 1: Migrations issues fix

### DIFF
--- a/src/exampleco/migrations/database/versions/483beda0cf84_merge_two_heads_d3bdae443a1a_and_.py
+++ b/src/exampleco/migrations/database/versions/483beda0cf84_merge_two_heads_d3bdae443a1a_and_.py
@@ -1,0 +1,24 @@
+"""merge two heads d3bdae443a1a and 52ad861d3c4c
+
+Revision ID: 483beda0cf84
+Revises: d3bdae443a1a, 52ad861d3c4c
+Create Date: 2022-04-28 13:37:42.510251
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '483beda0cf84'
+down_revision = ('d3bdae443a1a', '52ad861d3c4c')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Details:
Migrations had two heads which caused error. Fixed the migration simply by merging them.
In order to merge two migrations one can use following command:

`alembic merge -m "message" head1 head2`

As a result, alembic generates another migration that resolves the conflict.