### PR TITLE
Overwrite default lambda timeout 

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -7,6 +7,7 @@ provider:
   name: aws
   runtime: python3.8
   lambdaHashingVersion: 20201221
+  timeout: 30
 
 functions:
   get_all_orders:


### PR DESCRIPTION
This PR overwrites the default function timeout of lambda to 30 seconds.